### PR TITLE
Fix: Non-ASCII characters in Sage text or comments.

### DIFF
--- a/ob-sagemath.el
+++ b/ob-sagemath.el
@@ -255,7 +255,8 @@ buffer."
         (raw-code (org-babel-expand-body:generic
                    (encode-coding-string body 'utf-8)
                    params (org-babel-variable-assignments:python params)))
-        (buf (current-buffer)))
+        (buf (current-buffer))
+	(coding-system-for-write 'utf-8))
 
     (ob-sagemath--init session sync)
 


### PR DESCRIPTION
Fix allowing non-ASCII characters in code or comments of Sage blocks.

The fix is to temporarily set the write-coding-system to 'utf-8 in
ob-sagemath.el.